### PR TITLE
Feat/changes

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -72,6 +72,9 @@ services:
       - "5173:5173"
     environment:
       - VITE_API_URL=http://backend:8080
+    volumes:
+      - ../frontend:/frontend
+      - /frontend/node_modules
     depends_on:
       - backend
     networks:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -72,9 +72,6 @@ services:
       - "5173:5173"
     environment:
       - VITE_API_URL=http://backend:8080
-    volumes:
-      - ../frontend:/frontend
-      - /frontend/node_modules
     depends_on:
       - backend
     networks:

--- a/frontend/src/components/admin/AddPolicyModal.vue
+++ b/frontend/src/components/admin/AddPolicyModal.vue
@@ -120,16 +120,16 @@
             <!-- Renewal Premium -->
             <div>
               <label class="block text-sm font-medium text-slate-700 mb-2"
-                >Renewal Premium (₹)</label
+                >Renewal Premium Rate</label
               >
               <input
                 v-model.number="form.renewalPremiumRate"
                 type="number"
                 required
-                min="1"
+                min="0"
                 step="0.01"
                 class="w-full px-4 py-3 border border-slate-200 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
-                placeholder="48000"
+                placeholder="0.01"
               />
             </div>
           </div>

--- a/frontend/src/components/policies/PolicyModal.vue
+++ b/frontend/src/components/policies/PolicyModal.vue
@@ -62,9 +62,9 @@
                   }}</span>
                 </div>
                 <div class="flex justify-between">
-                  <span class="text-slate-500">Renewal Premium</span>
+                  <span class="text-slate-500">Renewal Premium Rate</span>
                   <span class="font-semibold text-slate-900">{{
-                    formatINR(policy.renewalPremiumRate)
+                    policy.renewalPremiumRate
                   }}</span>
                 </div>
               </div>
@@ -249,8 +249,8 @@ const formatINR = (amount: number): string => {
   return new Intl.NumberFormat('en-IN', {
     style: 'currency',
     currency: 'INR',
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
   }).format(amount)
 }
 


### PR DESCRIPTION
This pull request updates the handling and display of renewal premium rates in the policy admin and details modals, and improves the formatting of currency values. The main changes include renaming the renewal premium field to "Renewal Premium Rate," adjusting its input validation, and ensuring currency values consistently show two decimal places.

**Policy field and display updates:**

* Renamed the "Renewal Premium" label to "Renewal Premium Rate" in both the add policy modal (`AddPolicyModal.vue`) and the policy details modal (`PolicyModal.vue`). [[1]](diffhunk://#diff-731e05c9ef649efd13e00b1a2f6289bae9d57ce60a344b093b9d242c3a074a3dL123-R132) [[2]](diffhunk://#diff-2bd7cefadd606a3542f402fdf670a5584f520d35291804b533457ca437a6e45bL65-R67)
* Changed the input validation for the renewal premium rate field: minimum value is now `0` instead of `1`, and the placeholder is updated to `0.01` for clarity.
* Displayed the raw `renewalPremiumRate` value instead of formatting it as INR currency in the policy details modal.

**Currency formatting improvement:**

* Updated the `formatINR` function to always show two decimal places for INR values, ensuring consistency in currency display.